### PR TITLE
Fix observability test expectation for missing id

### DIFF
--- a/0002-Fix-observability-test-expectation-for-missing-id.patch
+++ b/0002-Fix-observability-test-expectation-for-missing-id.patch
@@ -1,0 +1,36 @@
+From 7fd8eaed62607f971e89682d3f2a893c339022ac Mon Sep 17 00:00:00 2001
+From: Reuben Bowlby <reuben@hummbl.io>
+Date: Fri, 2 Jan 2026 17:59:50 -0500
+Subject: [PATCH 2/3] Fix observability test expectation for missing id
+
+---
+ tests/test_observability.py | 8 +++++---
+ 1 file changed, 5 insertions(+), 3 deletions(-)
+
+diff --git a/tests/test_observability.py b/tests/test_observability.py
+index 432fe03..cdc74c1 100644
+--- a/tests/test_observability.py
++++ b/tests/test_observability.py
+@@ -160,14 +160,16 @@ def test_unknown_artifact_id():
+         "instance": "test",
+         "models": ["FM1"]
+     }
+-    
++
+     errors = validate_artifact(artifact, SCHEMA, MAPPINGS, ERR_REGISTRY, event_sink=event_sink)
+-    assert errors == []
+-    
++    assert errors == ["ERR-SCHEMA-001"], "Missing id should fail schema validation"
++
+     output.seek(0)
+     event = json.loads(output.read().strip())
+     
+     assert event["artifact_id"] == "unknown"
++    assert event["result"] == "failure"
++    assert "ERR-SCHEMA-001" in event["error_codes"]
+ 
+ 
+ def test_create_validator_event_with_correlation_id():
+-- 
+2.52.0
+


### PR DESCRIPTION
Updated the test to assert that missing id results in schema validation failure.