### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/verify-seed.yml
+++ b/.github/workflows/verify-seed.yml
@@ -13,6 +13,9 @@ on:
       - 'compliance/**'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   verify-seed-hash:
     name: Verify Seed Hash Matches MRCC


### PR DESCRIPTION
Potential fix for [https://github.com/hummbl-dev/base120/security/code-scanning/4](https://github.com/hummbl-dev/base120/security/code-scanning/4)

In general, this issue is fixed by explicitly adding a `permissions` block to the workflow (at the root level or per job) that grants only the minimal scopes required. For this workflow, the job only reads files after checking out the repository and does not modify issues, PRs, or repository contents, so `contents: read` is sufficient.

The single best fix with no functional change is to add a `permissions` section at the workflow root (near the top of `.github/workflows/verify-seed.yml`) so it applies to all jobs in this workflow. Insert:

```yaml
permissions:
  contents: read
```

between the `on:` block (lines 3–14) and the `jobs:` block (line 16). No other steps, jobs, or actions need changing, and no additional imports or methods are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
