### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/base120.yml
+++ b/.github/workflows/base120.yml
@@ -1,5 +1,8 @@
 name: Base120 CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/hummbl-dev/base120/security/code-scanning/3](https://github.com/hummbl-dev/base120/security/code-scanning/3)

In general, fix this by explicitly setting the `permissions` for the `GITHUB_TOKEN` either at the workflow root (applies to all jobs) or per job, granting only the scopes needed. This avoids inheriting potentially broad repository or organization defaults.

For this workflow, neither `mirror-guard` nor `test` requires write access; both only need to read the repository contents to check out code. The simplest least-privilege configuration is to set `permissions: contents: read` at the workflow root, just under the `name:` (or under `on:`), so it applies to all jobs. This directly addresses the CodeQL warning on the `test` job’s `runs-on` line, since CodeQL only requires that some explicit permissions block exist. Concretely, in `.github/workflows/base120.yml`, insert:

```yaml
permissions:
  contents: read
```

between the `name: Base120 CI` line and the `on:` block. No additional imports, methods, or other definitions are needed because this is purely a workflow configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
