### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/guardrails.yml
+++ b/.github/workflows/guardrails.yml
@@ -1,5 +1,8 @@
 name: Base120 Guardrails
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/hummbl-dev/base120/security/code-scanning/1](https://github.com/hummbl-dev/base120/security/code-scanning/1)

In general, to fix this issue you add an explicit `permissions` block that grants only the minimal required scopes to the `GITHUB_TOKEN`. For a simple test job that checks out code and runs tests without modifying repository data or PRs, `contents: read` is typically sufficient. This ensures the token cannot perform unintended write actions even if a downstream step or dependency is compromised.

The best way to fix this workflow without changing its behavior is to add a workflow-level `permissions` block directly under the `name` field. This will apply to all jobs (currently just `corpus`) unless a job overrides it. Given the current steps—`actions/checkout`, `actions/setup-python`, `pip install`, and `pytest`—no write permissions are required, so we can safely use `contents: read`. Concretely, edit `.github/workflows/guardrails.yml` to insert:

```yaml
permissions:
  contents: read
```

between the `name` line and the `on:` block. No imports or additional methods are needed because this is a YAML configuration change for GitHub Actions only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
