### PR TITLE
docs: add repository health contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ This repository is the **authoritative reference implementation** for Base120 v1
 
 Full governance spec: [GOVERNANCE.md](GOVERNANCE.md) | [Decision tree](docs/governance-decision-tree.md)
 
+Repository health contract: [docs/REPO_HEALTH.md](docs/REPO_HEALTH.md)
+
 ## HUMMBL Ecosystem
 
 Part of the [HUMMBL](https://github.com/hummbl-dev) cognitive AI architecture:

--- a/docs/REPO_HEALTH.md
+++ b/docs/REPO_HEALTH.md
@@ -1,0 +1,65 @@
+# Repository Health Contract
+
+## Ownership
+
+- **Repository**: `hummbl-dev/base120`
+- **Canonical URL**: `https://github.com/hummbl-dev/base120`
+- **Owner**: HUMMBL Team
+- **Stewardship scope**: Canonical Base120 registry, validation corpus, governance specs, and v1 reference artifacts.
+
+## Lifecycle
+
+- **Status**: Active public repository with the Python v1 package retired.
+- **Default branch**: `main`.
+- **Release posture**: v1 Python runtime code has been removed. Registry, corpus, governance, documentation, and CI hardening changes may continue through pull requests.
+- **Archive trigger**: Archive only if the canonical Base120 registry and validation corpus move to another declared source of truth.
+
+## Source Of Truth
+
+- `Base120_Canonical_Model_Registry.yaml` is the canonical model registry.
+- `registries/` contains registry data files that mirror or support the canonical model set.
+- `tests/corpus/` is the golden validation corpus for implementations and mirrors.
+- `GOVERNANCE.md` and `docs/governance-decision-tree.md` define change classes and review expectations.
+- `docs/contract-units.md` defines contract unit structure and examples.
+
+## Validation Contract
+
+Run from the repository root unless noted.
+
+```bash
+python -m pip install --upgrade pip
+pip install -e ".[test]"
+pytest
+python -m pytest tests/ -v
+```
+
+Expected CI coverage:
+
+- `.github/workflows/ci.yml` runs tests on Python 3.11 and 3.12.
+- `.github/workflows/base120.yml` runs mirror-guard checks and tests on Python 3.13.
+- `.github/workflows/guardrails.yml` runs corpus validation on Python 3.13.
+- `.github/workflows/mirror-conformance.yml` is a reusable mirror-conformance workflow for downstream implementations.
+
+## Branch Protection Expectation
+
+`main` should be treated as protected:
+
+- All non-trivial changes should land through pull requests.
+- Required checks should include the Python test matrix and corpus/guardrail validation where applicable.
+- Schema, corpus, registry, or formal model changes should follow the review classes in `GOVERNANCE.md`.
+- Direct pushes to `main` should be limited to emergency operator action.
+
+## Known Operational Gaps
+
+- GitHub branch protection is tracked centrally in `hummbl-dev/hummbl-dev#18`; do not overclaim required checks until that audit is updated.
+- The Python v1 package is retired, so validation should focus on registry, corpus, and mirror-conformance integrity rather than runtime feature growth.
+
+## Fleet Scan Classification
+
+Future fleet scans can classify this repository as:
+
+- **Lifecycle**: active, v1 runtime retired
+- **Visibility**: public
+- **Primary function**: canonical Base120 registry and validation corpus
+- **Validation entrypoint**: `pytest`
+- **Primary metadata owner**: HUMMBL Team


### PR DESCRIPTION
## Summary
- add `docs/REPO_HEALTH.md` for base120 ownership, lifecycle, source-of-truth, validation, branch-protection expectations, and fleet scan classification
- link the health contract from `README.md`

## Validation
- `git diff --check`
- `python -m pytest tests/ -q` (148 passed)

Refs hummbl-dev/hummbl-dev#21